### PR TITLE
Add six as requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ colorama
 hexdump
 pydocstyle
 flake8
+six

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(name='elementals',
       url='https://github.com/eyalitki/elementals',
       license='GPL',
       packages=find_packages(exclude=['tests']),
-      install_requires=['colorama', 'hexdump', 'pydocstyle', 'flake8'],
+      install_requires=['colorama', 'hexdump', 'pydocstyle', 'flake8', 'six'],
       classifiers=[
                     "Programming Language :: Python",
                     "License :: OSI Approved :: GNU General Public License (GPL)",


### PR DESCRIPTION
Elementals uses the Six module but doesn't contain it in its requirements.txt nor in its setup.py.
This pull request fixes this.